### PR TITLE
Unicode type is Py2 only

### DIFF
--- a/kinesis_producer/producer.py
+++ b/kinesis_producer/producer.py
@@ -42,8 +42,9 @@ class KinesisProducer(object):
         """
         assert not self._closed, "KinesisProducer closed but called anyway"
 
-        if isinstance(record, unicode):
-            record = record.encode('utf-8')
+        if six.PY2:
+            if isinstance(record, unicode):
+                record = record.encode('utf-8')
 
         if not isinstance(record, six.binary_type):
             raise ValueError("Record must be bytes type")


### PR DESCRIPTION
fixes exception like:
```
name 'unicode' is not defined: NameError
Traceback (most recent call last):
  File "/var/task/Submitter.py", line 40, in handler
    producer.send(name.encode(encoding='ascii'))
  File "/var/task/kinesis_producer/producer.py", line 45, in send
    if isinstance(record, unicode):
NameError: name 'unicode' is not defined
```
while using python3